### PR TITLE
Litecoin is now only hosted in legacy code

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         - name: ethereum
           repo: app-ethereum
         - name: litecoin
-          repo: app-bitcoin-new
+          repo: app-bitcoin
         - name: bitcoin
           repo: app-bitcoin-new
 


### PR DESCRIPTION
The bitcoin "new" repo is cuting off its legacy code, so now bitcoin-derivated are only hosted [in the legacy repo](https://github.com/LedgerHQ/app-bitcoin).