### PR TITLE
[update] Updating CHANGELOG with version swapping between 2.0.12 and 2.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.12](https://github.com/ledgerhq/app-exchange/compare/2.0.11...2.0.12) - 2022-??-??
+## [2.0.13](https://github.com/ledgerhq/app-exchange/compare/2.0.12...2.0.13) - 2022-??-??
 
 ### Changed
 
 - Application name length is no longer caped to 15B, but synced with BOLOS maximum length
+
+## [2.0.12](https://github.com/ledgerhq/app-exchange/compare/2.0.11...2.0.12) - 2022-10-19
+
+### Added
+
+- DERIVE_MASTER flag, needed for app-bitcoin-new v2.1+
 
 ## [2.0.11](https://github.com/ledgerhq/app-exchange/compare/2.0.3...2.0.11) - 2022-05-24
 


### PR DESCRIPTION
@fbeutin-ledger in anticipation of app-bitcoin-new 2.1, there was some change in anticipated versions:

- the tagged `2.0.12-dev` which is waiting for some time, could now rather be considered as a `2.0.13-dev` (although not tagged yet)
- a 2.0.12 has been release with only a very small change in the `Makefile`, to comply with BTC futur permission needs.

So this PR changes the CHANGELOG accordingly.