### PR TITLE
test: python: Allow tests with ledgerwallet backend

### DIFF
--- a/test/python/apps/exchange.py
+++ b/test/python/apps/exchange.py
@@ -213,4 +213,7 @@ class ExchangeClient:
         if rapdu.status == 0x9000:
             # If the exchange app accepts starting the library app, give it time to actually start
             sleep(0.5)
+
+            # The USB stack will be reset by the called app
+            self._client.handle_usb_reset()
         return rapdu

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -7,6 +7,8 @@ from ragger.conftest import configuration
 # You can configure optional parameters by overriding the value of ragger.configuration.OPTIONAL_CONFIGURATION
 # Please refer to ragger/conftest/configuration.py for their descriptions and accepted values
 
+configuration.OPTIONAL.APP_NAME = "Exchange"
+
 configuration.OPTIONAL.SIDELOADED_APPS = {
     "bitcoin": "Bitcoin",
     "bitcoin_legacy": "Bitcoin Legacy",

--- a/test/python/test_ripple.py
+++ b/test/python/test_ripple.py
@@ -186,7 +186,7 @@ def test_ripple_swap_refuse_double_sign(backend, navigator, test_name):
     performer.perform_valid_swap(backend, navigator, test_name)
     performer.perform_ripple_tx(backend)
 
-    with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead)):
+    with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead, OSError)):
         performer.perform_ripple_tx(backend)
 
 
@@ -275,7 +275,7 @@ def test_ripple_swap_wrong_amount(backend, navigator, test_name):
 #     performer.perform_valid_fund(backend, navigator, test_name)
 #     performer.perform_ripple_tx(backend)
 
-#     with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead)):
+#     with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead, OSError)):
 #         performer.perform_ripple_tx(backend)
 
 
@@ -365,7 +365,7 @@ def test_ripple_swap_wrong_amount(backend, navigator, test_name):
 #     performer.perform_valid_sell(backend, navigator, test_name)
 #     performer.perform_ripple_tx(backend)
 
-#     with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead)):
+#     with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead, OSError)):
 #         performer.perform_ripple_tx(backend)
 
 

--- a/test/python/test_stellar.py
+++ b/test/python/test_stellar.py
@@ -183,7 +183,7 @@ def test_stellar_swap_refuse_double_sign(backend, navigator, test_name):
     performer.perform_valid_swap(backend, navigator, test_name)
     performer.perform_stellar_tx(backend)
 
-    with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead)):
+    with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead, OSError)):
         performer.perform_stellar_tx(backend)
 
 
@@ -272,7 +272,7 @@ def test_stellar_fund_refuse_double_sign(backend, navigator, test_name):
     performer.perform_valid_fund(backend, navigator, test_name)
     performer.perform_stellar_tx(backend)
 
-    with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead)):
+    with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead, OSError)):
         performer.perform_stellar_tx(backend)
 
 
@@ -362,7 +362,7 @@ def test_stellar_sell_refuse_double_sign(backend, navigator, test_name):
     performer.perform_valid_sell(backend, navigator, test_name)
     performer.perform_stellar_tx(backend)
 
-    with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead)):
+    with pytest.raises((ChunkedEncodingError, ConnectionError, ProtocolError, IncompleteRead, OSError)):
         performer.perform_stellar_tx(backend)
 
 


### PR DESCRIPTION
This is mainly using the new ragger backend instantiation feature and ledgerwallet handling of USB reboot.

Linked to https://github.com/LedgerHQ/ragger/pull/119