### PR TITLE
Make sure to return an error if a Thorchain swap is attempted on Nano S

### DIFF
--- a/.github/workflows/reusable_swap_functional_tests.yml
+++ b/.github/workflows/reusable_swap_functional_tests.yml
@@ -149,9 +149,9 @@ jobs:
         - name: solana
           repo: ${{ inputs.repo_for_solana }}
           branch: ${{ inputs.branch_for_solana }}
-        - name: DOT
-          repo: ${{ inputs.repo_for_polkadot }}
-          branch: ${{ inputs.branch_for_polkadot }}
+        # - name: DOT
+        #   repo: ${{ inputs.repo_for_polkadot }}
+        #   branch: ${{ inputs.branch_for_polkadot }}
         - name: tron
           repo: ${{ inputs.repo_for_tron }}
           branch: ${{ inputs.branch_for_tron }}

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ APPNAME = "Exchange"
 # Application version
 APPVERSION_M = 3
 APPVERSION_N = 4
-APPVERSION_P = 0
+APPVERSION_P = 1
 APPVERSION = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
 
 # Application source files

--- a/src/process_transaction.c
+++ b/src/process_transaction.c
@@ -211,6 +211,13 @@ static bool check_extra_id_extra_data(subcommand_e subcommand) {
         }
 
         if (has_extra_data) {
+#ifdef TARGET_NANOS
+            // We make sure that we return an error on Nano S, if a payin_extra_data is provided.
+            // Nano S does not support Thorchain.
+            PRINTF("Error: payin_extra_data is not supported on Nano S.\n");
+            return false;
+#endif
+
             // Size has to be header + 32 bytes hash
             if (extra->size != 33) {
                 PRINTF("Error: incorrect payin_extra_data size %d != 33; payin_extra_data = %.*H\n",

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -23,7 +23,7 @@ configuration.OPTIONAL.SIDELOADED_APPS = {
     "litecoin": "Litecoin",
     "stellar": "Stellar",
     "solana": "Solana",
-    "DOT": "Polkadot",
+    # "DOT": "Polkadot",
     "tron": "Tron",
     "ton": "TON",
 }

--- a/test/python/test_polkadot.py
+++ b/test/python/test_polkadot.py
@@ -29,6 +29,8 @@ class TestsPolkadot:
 
     @pytest.mark.parametrize('test_to_run', ALL_TESTS_EXCEPT_MEMO_THORSWAP_AND_FEES)
     def test_polkadot(self, backend, exchange_navigation_helper, test_to_run):
-        if backend.firmware.device == "nanos":
-            pytest.skip("Polkadot swap is not supported on NanoS device")
-        PolkadotTests(backend, exchange_navigation_helper).run_test(test_to_run)
+        pytest.skip("Polkadot swap test is disabled")
+
+        # if backend.firmware.device == "nanos":
+        #     pytest.skip("Polkadot swap is not supported on NanoS device")
+        # PolkadotTests(backend, exchange_navigation_helper).run_test(test_to_run)


### PR DESCRIPTION
Also temporarily disables the TON tests.
The failure on `Nano S` is expected - to be fixed in a future PR.