### PR TITLE
[tezos] update tests according to the Tezos Seoul protocol

### DIFF
--- a/test/python/apps/tezos.py
+++ b/test/python/apps/tezos.py
@@ -215,6 +215,7 @@ class TezosClient:
         payload += bytes.fromhex("00") # storage limit
         payload += SIGNATURE_TYPE.ED25519.to_bytes(1, byteorder='big')
         payload += device_pk # pubkey of the device
+        payload += bytes.fromhex("00") # no proof
 
         # Operation 2 OPERATION_TAG_BABYLON_TRANSACTION
         payload += OPERATION_TAG.OPERATION_TAG_BABYLON_TRANSACTION.to_bytes(1, byteorder='big')


### PR DESCRIPTION
With the announcement of the new Tezos protocol: Seoul, the [Tezos Wallet App](https://github.com/trilitech/ledger-app-tezos-wallet) will be updated.\
To follow the development of the wallet app, some changes, regarding encoding in the Tezos tests, are needed.

The Seoul protocol introduced the aggregation of consensus operations using BLS. With this change comes a new `proof` field when revealing a BLS key.

This PR updates the encoding of the revelation operation by adding the new `proof` field.\
This field is not critical for swap and since the tests use a tz1 key rather than a tz4 (BLS) key, the proof field is left empty.

# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [ ] App update process has been followed <!-- See comment below -->
- [ ] Target branch is `develop` <!-- unless you have a very good reason -->
- [ ] Application version has been bumped <!-- required if your changes are to be deployed -->